### PR TITLE
Fix: fsGroup is not declared in schema

### DIFF
--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -114,7 +114,6 @@ spec:
             runAsNonRoot: true
             runAsUser: {{ .Values.user.uid }}
             runAsGroup:  {{ .Values.user.gid }}
-            fsGroup: {{ .Values.user.uid }}
             {{- with .Values.extraSecurityContext }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
There is a difference between pod level securitycontext and container level.
fsGroup is not defined on pod level.
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core